### PR TITLE
update

### DIFF
--- a/Foundry.cs/Foundry.cs
+++ b/Foundry.cs/Foundry.cs
@@ -56,12 +56,10 @@ namespace WindowsGSM.Plugins
         public string DefaultPause = "true"; //  Will the server pause when nobody is connected.
         public string DefaultAutoSaveInterval = "300"; // Sets the autosave frequency in seconds.
         public string DefaultPublic = "true"; // Sets whether the server is listed on the Steam server browser.
-        public string DefaultFolder = "Server01"; // Sets the absolute folder where things like logs and save files will be stored. This is mostly used by server providers so that they can run multiple dedicated servers on a single machine.
         // TODO: Unsupported option
 
         // TODO: May not support
         public string Additional = ""; // Additional server start parameter
-
 
 
         // - Create a default cfg for the game server after installation
@@ -101,7 +99,7 @@ namespace WindowsGSM.Plugins
                     writer.WriteLine($"map_seed={serverData.ServerMap}");
                     writer.WriteLine($"//server_persistent_data_override_folder");
                     writer.WriteLine($"//Sets the absolute folder where things like logs and save files will be stored. This is mostly used by server providers so that they can run multiple dedicated servers on a single machine.");
-                    writer.WriteLine($"server_persistent_data_override_folder={DefaultFolder}");
+                    writer.WriteLine($"server_persistent_data_override_folder={serverData.ServerName}");
                     writer.WriteLine($"//server_name");
                     writer.WriteLine($"//This is the name of the server listed in the Steam server browser.");
                     writer.WriteLine($"server_name={serverData.ServerName}");
@@ -119,6 +117,7 @@ namespace WindowsGSM.Plugins
                 Error = $"Error Occured : {ex.Message}";
             }
         }
+
         public void UpdateCFG()
         {
             // Chemin complet du fichier

--- a/Foundry.cs/Foundry.cs
+++ b/Foundry.cs/Foundry.cs
@@ -237,9 +237,11 @@ namespace WindowsGSM.Plugins
             {
                 Functions.ServerConsole.SetMainWindow(p.MainWindowHandle);
                 Functions.ServerConsole.SendWaitToMainWindow("^c");
-                p.WaitForExit(20000);
+                p.WaitForExit(7000);
+                p.Kill();
             });
         }
+
 
         // fixes WinGSM bug, https://github.com/WindowsGSM/WindowsGSM/issues/57#issuecomment-983924499
         public async Task<Process> Update(bool validate = false, string custom = null)

--- a/Foundry.cs/Foundry.cs
+++ b/Foundry.cs/Foundry.cs
@@ -102,8 +102,7 @@ namespace WindowsGSM.Plugins
                     writer.Close();
                 }
 
-                var serverConsole = new ServerConsole(serverData.ServerID);
-                serverConsole.Add($"ConfigFile {ConfigFile} successfully created!");
+                Notice = $"ConfigFile {ConfigFile} successfully created!";
             }
             catch (Exception ex)
             {
@@ -162,8 +161,7 @@ namespace WindowsGSM.Plugins
 
                 File.WriteAllText(filePath, sb.ToString());
 
-                var serverConsole = new ServerConsole(serverData.ServerID);
-                serverConsole.Add($"ConfigFile {ConfigFile} successfully updated!");
+                Notice = $"ConfigFile {ConfigFile} successfully updated!";
             }
             catch (Exception ex)
             {

--- a/Foundry.cs/Foundry.cs
+++ b/Foundry.cs/Foundry.cs
@@ -115,6 +115,12 @@ namespace WindowsGSM.Plugins
         {
             // Chemin complet du fichier
             string filePath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, ConfigFile);
+            if (!File.Exists(filePath))
+            {
+                Notice = $"For some unknown reason {ConfigFile} did not exist. Recreating it. not sure what this means about your savegame though. possible, that you need to move it to the new folder if there is any";
+                CreateServerCFG();
+                return;
+            }
             StringBuilder sb = new StringBuilder();
             try
             {

--- a/Foundry.cs/Foundry.cs
+++ b/Foundry.cs/Foundry.cs
@@ -99,7 +99,7 @@ namespace WindowsGSM.Plugins
                     writer.WriteLine($"map_seed={serverData.ServerMap}");
                     writer.WriteLine($"//server_persistent_data_override_folder");
                     writer.WriteLine($"//Sets the absolute folder where things like logs and save files will be stored. This is mostly used by server providers so that they can run multiple dedicated servers on a single machine.");
-                    writer.WriteLine($"server_persistent_data_override_folder={serverData.ServerName}");
+                    writer.WriteLine($"server_persistent_data_override_folder=Server{serverData.ServerID}");
                     writer.WriteLine($"//server_name");
                     writer.WriteLine($"//This is the name of the server listed in the Steam server browser.");
                     writer.WriteLine($"server_name={serverData.ServerName}");

--- a/Foundry.cs/Foundry.cs
+++ b/Foundry.cs/Foundry.cs
@@ -66,57 +66,59 @@ namespace WindowsGSM.Plugins
 
         // - Create a default cfg for the game server after installation
         public async void CreateAppCFG()
-		{
-			string fileName = "app.cfg";
-			// Chemin complet du fichier
-			string filePath = Path.Combine(Environment.CurrentDirectory, fileName);
-			
-			try
-			{
-			// Créer le fichier
-			using (StreamWriter writer = new StreamWriter(filePath))
-			{
-            // Écrire les informations dans le fichier
-			writer.WriteLine($"//Available Options:");
-			writer.WriteLine($"//server_world_name");
-			writer.WriteLine($"//Sets the server world name. This is the folder where the save files will be stored.");
-			writer.WriteLine($"server_world_name={serverData.ServerName}");
-			writer.WriteLine($"//server_password");
-			writer.WriteLine($"//Sets the server password.");
-			writer.WriteLine($"server_password={ServerPassword}");
-			writer.WriteLine($"//pause_server_when_empty");
-			writer.WriteLine($"//Will the server pause when nobody is connected.");
-			writer.WriteLine($"pause_server_when_empty={DefaultPause}");
-			writer.WriteLine($"//autosave_interval");
-			writer.WriteLine($"//Sets the autosave frequency in seconds.");
-			writer.WriteLine($"autosave_interval={DefaultAutoSaveInterval}");
-			writer.WriteLine($"//server_is_public");
-			writer.WriteLine($"//Sets whether the server is listed on the Steam server browser.");
-			writer.WriteLine($"server_is_public={DefaultPublic}");
-			writer.WriteLine($"//server_port");
-			writer.WriteLine($"//Sets the network port used by the game. Default is 3724.");
-			writer.WriteLine($"server_port={serverData.ServerPort}");
-			writer.WriteLine($"//map_seed");
-			writer.WriteLine($"//Sets the map seed used to generate the world.");
-			writer.WriteLine($"map_seed={serverData.ServerMap}");
-			writer.WriteLine($"//server_persistent_data_override_folder");
-			writer.WriteLine($"//Sets the absolute folder where things like logs and save files will be stored. This is mostly used by server providers so that they can run multiple dedicated servers on a single machine.");
-			writer.WriteLine($"server_persistent_data_override_folder={DefaultFolder}");
-			writer.WriteLine($"//server_name");
-			writer.WriteLine($"//This is the name of the server listed in the Steam server browser.");
-			writer.WriteLine($"server_name={serverData.ServerName}");
-			writer.WriteLine($"//server_max_players");
-			writer.WriteLine($"//This sets the max amount of players on a server.");
-			writer.WriteLine($"server_max_players={serverData.ServerMaxPlayer}");
-			}	
+        {
+            string fileName = "app.cfg";
+            // Chemin complet du fichier
+            string filePath = Path.Combine(Environment.CurrentDirectory, fileName);
 
-			Console.WriteLine("Fichier app.cfg créé avec succès !");
-			}
-			catch (Exception ex)
-			{
-				Console.WriteLine($"Une erreur s'est produite : {ex.Message}");
-			}
-		}
+            try
+            {
+                // Créer le fichier
+                using (StreamWriter writer = new StreamWriter(filePath))
+                {
+                    // Écrire les informations dans le fichier
+                    writer.WriteLine($"//Available Options:");
+                    writer.WriteLine($"//server_world_name");
+                    writer.WriteLine($"//Sets the server world name. This is the folder where the save files will be stored.");
+                    writer.WriteLine($"server_world_name={serverData.ServerName}");
+                    writer.WriteLine($"//server_password");
+                    writer.WriteLine($"//Sets the server password.");
+                    writer.WriteLine($"server_password={ServerPassword}");
+                    writer.WriteLine($"//pause_server_when_empty");
+                    writer.WriteLine($"//Will the server pause when nobody is connected.");
+                    writer.WriteLine($"pause_server_when_empty={DefaultPause}");
+                    writer.WriteLine($"//autosave_interval");
+                    writer.WriteLine($"//Sets the autosave frequency in seconds.");
+                    writer.WriteLine($"autosave_interval={DefaultAutoSaveInterval}");
+                    writer.WriteLine($"//server_is_public");
+                    writer.WriteLine($"//Sets whether the server is listed on the Steam server browser.");
+                    writer.WriteLine($"server_is_public={DefaultPublic}");
+                    writer.WriteLine($"//server_port");
+                    writer.WriteLine($"//Sets the network port used by the game. Default is 3724.");
+                    writer.WriteLine($"server_port={serverData.ServerPort}");
+                    writer.WriteLine($"//map_seed");
+                    writer.WriteLine($"//Sets the map seed used to generate the world.");
+                    writer.WriteLine($"map_seed={serverData.ServerMap}");
+                    writer.WriteLine($"//server_persistent_data_override_folder");
+                    writer.WriteLine($"//Sets the absolute folder where things like logs and save files will be stored. This is mostly used by server providers so that they can run multiple dedicated servers on a single machine.");
+                    writer.WriteLine($"server_persistent_data_override_folder={DefaultFolder}");
+                    writer.WriteLine($"//server_name");
+                    writer.WriteLine($"//This is the name of the server listed in the Steam server browser.");
+                    writer.WriteLine($"server_name={serverData.ServerName}");
+                    writer.WriteLine($"//server_max_players");
+                    writer.WriteLine($"//This sets the max amount of players on a server.");
+                    writer.WriteLine($"server_max_players={serverData.ServerMaxPlayer}");
+                    writer.Close();
+                }
+
+                var serverConsole = new ServerConsole(serverData.ServerID);
+                serverConsole.Add($"ConfigFile {ConfigFile} successfully created!");
+            }
+            catch (Exception ex)
+            {
+                Error = $"Error Occured : {ex.Message}";
+            }
+        }
         public void UpdateCFG()
         {
             // Chemin complet du fichier
@@ -197,33 +199,27 @@ namespace WindowsGSM.Plugins
                     WorkingDirectory = ServerPath.GetServersServerFiles(serverData.ServerID),
                     FileName = shipExePath,
                     Arguments = param,
-                    WindowStyle = ProcessWindowStyle.Normal,
-                    CreateNoWindow = false,
-                    UseShellExecute = false
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
                 },
                 EnableRaisingEvents = true
             };
 
-            // Set up Redirect Input and Output to WindowsGSM Console if EmbedConsole is on
-            if (AllowsEmbedConsole)
-            {
-                p.StartInfo.RedirectStandardInput = true;
-                p.StartInfo.RedirectStandardOutput = true;
-                p.StartInfo.RedirectStandardError = true;
-                var serverConsole = new ServerConsole(serverData.ServerID);
-                p.OutputDataReceived += serverConsole.AddOutput;
-                p.ErrorDataReceived += serverConsole.AddOutput;
-            }
+            var serverConsole = new ServerConsole(serverData.ServerID);
+            p.OutputDataReceived += serverConsole.AddOutput;
+            p.ErrorDataReceived += serverConsole.AddOutput;
 
             // Start Process
             try
             {
                 p.Start();
-                if (AllowsEmbedConsole)
-                {
-                    p.BeginOutputReadLine();
-                    p.BeginErrorReadLine();
-                }
+                p.BeginOutputReadLine();
+                p.BeginErrorReadLine();
+
                 return p;
             }
             catch (Exception e)
@@ -234,7 +230,7 @@ namespace WindowsGSM.Plugins
         }
 
 
-// - Stop server function
+        // - Stop server function
         public async Task Stop(Process p)
         {
             await Task.Run(() =>
@@ -245,7 +241,7 @@ namespace WindowsGSM.Plugins
             });
         }
 
-// fixes WinGSM bug, https://github.com/WindowsGSM/WindowsGSM/issues/57#issuecomment-983924499
+        // fixes WinGSM bug, https://github.com/WindowsGSM/WindowsGSM/issues/57#issuecomment-983924499
         public async Task<Process> Update(bool validate = false, string custom = null)
         {
             var (p, error) = await Installer.SteamCMD.UpdateEx(serverData.ServerID, AppId, validate, custom: custom, loginAnonymous: loginAnonymous);

--- a/Foundry.cs/Foundry.cs
+++ b/Foundry.cs/Foundry.cs
@@ -5,9 +5,7 @@ using WindowsGSM.Functions;
 using WindowsGSM.GameServer.Query;
 using WindowsGSM.GameServer.Engine;
 using System.IO;
-using System.Linq;
-using System.Net;
-
+using System.Text;
 
 namespace WindowsGSM.Plugins
 {
@@ -29,41 +27,45 @@ namespace WindowsGSM.Plugins
         public override string AppId => "2915550"; // Game server appId Steam
 
         // - Standard Constructor and properties
-        public Foundry(ServerConfig serverData) : base(serverData) => base.serverData = _serverData = serverData;
-        private readonly ServerConfig _serverData;
-        public string Error, Notice;
+        public Foundry(ServerConfig serverData) : base(serverData)
+        {
+            //create a random seed
+            serverData.ServerMap = new Random().Next().ToString();
+            base.serverData = serverData;
+        }
 
 
         // - Game server Fixed variables
         public override string StartPath => @".\FoundryDedicatedServer.exe"; // Game server start path
+        public string ConfigFile = "App.cfg";
         public string FullName = "Foundry Dedicated Server"; // Game server FullName
-        public bool AllowsEmbedConsole = true;  // Does this server support output redirect?
+        public bool AllowsEmbedConsole = false;  // Only Embedd Console
         public int PortIncrements = 1; // This tells WindowsGSM how many ports should skip after installation
 
         // TODO: Undisclosed method
         public object QueryMethod = new A2S(); // Query method should be use on current server type. Accepted value: null or new A2S() or new FIVEM() or new UT3()
 
         // - Game server default values
-		public string ServerName = "HappyPlace";
-		public string ServerWorldName = "MyFancyFactory";
+        public string ServerName = "HappyPlace";
         public string Port = "3724"; // Default port
-		public string ServerPassword = "only_friends"; //password to connect
-        public string Defaultmap = "MyFancyFactory"; // Default map name
-		public string DefaultPause = "true"; //  Will the server pause when nobody is connected.
-		public string DefaultAutoSaveInterval = "300"; // Sets the autosave frequency in seconds.
-		public string DefaultPublic = "true"; // Sets whether the server is listed on the Steam server browser.
-		public string DefaultMapSeed = "42938743982"; //  Sets the map seed used to generate the world.
-		public string DefaultFolder = "Server01"; // Sets the absolute folder where things like logs and save files will be stored. This is mostly used by server providers so that they can run multiple dedicated servers on a single machine.
+        public string QueryPort = "3724"; // Default port
+        public string Defaultmap = "1"; // Sets the map seed used to generate the world.
         public string Maxplayers = "32"; // Default maxplayers
-        
+
+        public string ServerPassword = "only_friends"; //password to connect
+        public string DefaultPause = "true"; //  Will the server pause when nobody is connected.
+        public string DefaultAutoSaveInterval = "300"; // Sets the autosave frequency in seconds.
+        public string DefaultPublic = "true"; // Sets whether the server is listed on the Steam server browser.
+        public string DefaultFolder = "Server01"; // Sets the absolute folder where things like logs and save files will be stored. This is mostly used by server providers so that they can run multiple dedicated servers on a single machine.
         // TODO: Unsupported option
 
         // TODO: May not support
         public string Additional = ""; // Additional server start parameter
 
 
+
         // - Create a default cfg for the game server after installation
-		public async void CreateAppCFG()
+        public async void CreateAppCFG()
 		{
 			string fileName = "app.cfg";
 			// Chemin complet du fichier
@@ -78,7 +80,7 @@ namespace WindowsGSM.Plugins
 			writer.WriteLine($"//Available Options:");
 			writer.WriteLine($"//server_world_name");
 			writer.WriteLine($"//Sets the server world name. This is the folder where the save files will be stored.");
-			writer.WriteLine($"server_world_name={ServerWorldName}");
+			writer.WriteLine($"server_world_name={serverData.ServerName}");
 			writer.WriteLine($"//server_password");
 			writer.WriteLine($"//Sets the server password.");
 			writer.WriteLine($"server_password={ServerPassword}");
@@ -93,19 +95,19 @@ namespace WindowsGSM.Plugins
 			writer.WriteLine($"server_is_public={DefaultPublic}");
 			writer.WriteLine($"//server_port");
 			writer.WriteLine($"//Sets the network port used by the game. Default is 3724.");
-			writer.WriteLine($"server_port={Port}");
+			writer.WriteLine($"server_port={serverData.ServerPort}");
 			writer.WriteLine($"//map_seed");
 			writer.WriteLine($"//Sets the map seed used to generate the world.");
-			writer.WriteLine($"map_seed={DefaultMapSeed}");
+			writer.WriteLine($"map_seed={serverData.ServerMap}");
 			writer.WriteLine($"//server_persistent_data_override_folder");
 			writer.WriteLine($"//Sets the absolute folder where things like logs and save files will be stored. This is mostly used by server providers so that they can run multiple dedicated servers on a single machine.");
 			writer.WriteLine($"server_persistent_data_override_folder={DefaultFolder}");
 			writer.WriteLine($"//server_name");
 			writer.WriteLine($"//This is the name of the server listed in the Steam server browser.");
-			writer.WriteLine($"server_name={ServerName}");
+			writer.WriteLine($"server_name={serverData.ServerName}");
 			writer.WriteLine($"//server_max_players");
 			writer.WriteLine($"//This sets the max amount of players on a server.");
-			writer.WriteLine($"server_max_players={Maxplayers}");
+			writer.WriteLine($"server_max_players={serverData.ServerMaxPlayer}");
 			}	
 
 			Console.WriteLine("Fichier app.cfg créé avec succès !");
@@ -115,21 +117,74 @@ namespace WindowsGSM.Plugins
 				Console.WriteLine($"Une erreur s'est produite : {ex.Message}");
 			}
 		}
+        public void UpdateCFG()
+        {
+            // Chemin complet du fichier
+            string filePath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, ConfigFile);
+            StringBuilder sb = new StringBuilder();
+            try
+            {
+                StreamReader sr = new StreamReader(filePath);
+                var line = sr.ReadLine();
+                while (line != null)
+                {
+                    if (line.Contains("server_world_name"))
+                    {
+                        sb.Append($"server_world_name={serverData.ServerName}");
+                        continue;
+                    }
+                    if (line.Contains("server_port"))
+                    {
+                        sb.Append($"server_port={serverData.ServerPort}");
+                        continue;
+                    }
+                    if (line.Contains("server_name"))
+                    {
+                        sb.Append($"server_name={serverData.ServerName}");
+                        continue;
+                    }
+                    if (line.Contains("map_seed"))
+                    {
+                        sb.Append($"map_seed={serverData.ServerMap}");
+                        continue;
+                    }
+                    if (line.Contains("server_max_players"))
+                    {
+                        sb.Append($"server_max_players={serverData.ServerMaxPlayer}");
+                        continue;
+                    }
+
+                    sb.Append(line);
+
+                    line = sr.ReadLine();
+                }
+                sr.Close();
+
+                File.WriteAllText(filePath, sb.ToString());
+
+                var serverConsole = new ServerConsole(serverData.ServerID);
+                serverConsole.Add($"ConfigFile {ConfigFile} successfully updated!");
+            }
+            catch (Exception ex)
+            {
+                Error = $"Error Occured : {ex.Message}";
+            }
+        }
 
 
         // - Start server function, return its Process to WindowsGSM
         public async Task<Process> Start()
         {
-            string shipExePath = Functions.ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath);
+            string shipExePath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, StartPath);
             if (!File.Exists(shipExePath))
             {
                 Error = $"{Path.GetFileName(shipExePath)} not found ({shipExePath})";
                 return null;
             }
-
+            UpdateCFG();
             // Prepare start parameter
             string param = "FactoryGame -log -unattended";
-            param += $" {_serverData.ServerParam}";
+            param += $" {serverData.ServerParam}";
             //param += string.IsNullOrWhiteSpace(_serverData.ServerPort) ? string.Empty : $" -Port={_serverData.ServerPort}"; 
             //param += string.IsNullOrWhiteSpace(_serverData.ServerQueryPort) ? string.Empty : $" -ServerQueryPort={_serverData.ServerQueryPort}";
             //param += string.IsNullOrWhiteSpace(_serverData.ServerIP) ? string.Empty : $" -Multihome={_serverData.ServerIP}";
@@ -139,7 +194,7 @@ namespace WindowsGSM.Plugins
             {
                 StartInfo =
                 {
-                    WorkingDirectory = ServerPath.GetServersServerFiles(_serverData.ServerID),
+                    WorkingDirectory = ServerPath.GetServersServerFiles(serverData.ServerID),
                     FileName = shipExePath,
                     Arguments = param,
                     WindowStyle = ProcessWindowStyle.Normal,
@@ -155,7 +210,7 @@ namespace WindowsGSM.Plugins
                 p.StartInfo.RedirectStandardInput = true;
                 p.StartInfo.RedirectStandardOutput = true;
                 p.StartInfo.RedirectStandardError = true;
-                var serverConsole = new ServerConsole(_serverData.ServerID);
+                var serverConsole = new ServerConsole(serverData.ServerID);
                 p.OutputDataReceived += serverConsole.AddOutput;
                 p.ErrorDataReceived += serverConsole.AddOutput;
             }

--- a/Foundry.cs/Foundry.cs
+++ b/Foundry.cs/Foundry.cs
@@ -27,13 +27,7 @@ namespace WindowsGSM.Plugins
         public override string AppId => "2915550"; // Game server appId Steam
 
         // - Standard Constructor and properties
-        public Foundry(ServerConfig serverData) : base(serverData)
-        {
-            //create a random seed
-            serverData.ServerMap = new Random().Next().ToString();
-            base.serverData = serverData;
-        }
-
+        public Foundry(ServerConfig _serverData) : base(_serverData) => serverData = _serverData;
 
         // - Game server Fixed variables
         public override string StartPath => @".\FoundryDedicatedServer.exe"; // Game server start path
@@ -49,7 +43,7 @@ namespace WindowsGSM.Plugins
         public string ServerName = "HappyPlace";
         public string Port = "3724"; // Default port
         public string QueryPort = "3724"; // Default port
-        public string Defaultmap = "1"; // Sets the map seed used to generate the world.
+        public string Defaultmap = new Random().Next().ToString(); // Sets the map seed used to generate the world.
         public string Maxplayers = "32"; // Default maxplayers
 
         public string ServerPassword = "only_friends"; //password to connect
@@ -63,11 +57,10 @@ namespace WindowsGSM.Plugins
 
 
         // - Create a default cfg for the game server after installation
-        public async void CreateAppCFG()
+        public async void CreateServerCFG()
         {
-            string fileName = "app.cfg";
             // Chemin complet du fichier
-            string filePath = Path.Combine(Environment.CurrentDirectory, fileName);
+            string filePath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, ConfigFile);
 
             try
             {


### PR DESCRIPTION
initially i only wanted to fix the bug, but then my programming background kicked in and i cleaned it up 

steps done:
- QueryPort Added back 
- used either WindowsGSM Console output(not console.writeline) or directly the Error variable (dedicated string buffer for errors, handled by WindowsGSM)
- always embedd console, as there is no windows Opened on default
- seperated your config Variables and the one for WindowsGSM
- same name for serverName and ServerWorldName
- use Server Map variable for the Mapseed, also random generated

You need an emergency exit in the Stop function(and 10 sec is the absolute max for that)

You can't rename base Functions. CreateServerCFG is called on install by name. renaming will cause it to not be found.

added an updateCfg function before start
